### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,16 +14,18 @@
 	"bugs": {
 		"url": "https://github.com/xzf158/grunt-request-upload/issues"
 	},
-	"licenses": [{
-		"type": "MIT",
-		"url": "https://github.com/xzf158/grunt-request-upload/blob/master/LICENSE-MIT"
-	}],
+	"licenses": [
+		{
+			"type": "MIT",
+			"url": "https://github.com/xzf158/grunt-request-upload/blob/master/LICENSE-MIT"
+		}
+	],
 	"main": "Gruntfile.js",
 	"engines": {
 		"node": ">= 0.8.0"
 	},
 	"scripts": {
-		"test": "grunt test"
+		"start": "node lemon-server.js"
 	},
 	"devDependencies": {
 		"grunt-contrib-jshint": "~0.6.0",
@@ -31,7 +33,7 @@
 		"grunt": "~0.4.1"
 	},
 	"peerDependencies": {
-		"grunt": "~0.4.1"
+		"grunt": ">=0.4.0"
 	},
 	"keywords": [
 		"gruntplugin",
@@ -45,8 +47,5 @@
 	"dependencies": {
 		"progress": "^1.1.8",
 		"request": "^2.65.0"
-	},
-	"scripts": {
-		"start": "node lemon-server.js"
 	}
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
